### PR TITLE
Isqliteconnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "version": "0.1.0-SNAPSHOT",
   "description": "A persistent, embedded knowledge base inspired by Datomic and DataScript.",
   "dependencies": {
+    "promise-sqlite": "1.2.0",
     "source-map-support": "ncalexan/node-source-map-support#fileUrls-plus",
     "sqlite3": "mossop/node-sqlite3#v3.1.4.1",
     "thenify-all": "^1.6.0",

--- a/src/datomish/promise-sqlite.cljs
+++ b/src/datomish/promise-sqlite.cljs
@@ -1,0 +1,48 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+(ns datomish.promise-sqlite
+  (:require
+   [datomish.sqlite :as s]
+   [cljs.nodejs :as nodejs]))
+
+(def sqlite (nodejs/require "promise-sqlite"))
+
+(defrecord SQLite3Connection [db]
+  s/ISQLiteConnection
+  (-each!
+    [db sql bindings row-cb]
+    (let [cb (fn [row]
+               (row-cb (js->clj row :keywordize-keys true)))]
+      (.each (.-db db) sql (or (clj->js bindings) #js []) (when row-cb cb))))
+
+  (in-transaction!
+    [db f]
+    (.inTransaction (.-db db) f))
+
+  (close!
+    [db]
+    (.close (.-db db))))
+
+(defn sqlite-connection
+  [path & {:keys [mode]}]
+  (.then (.open sqlite.DB path (clj->js {:mode mode})) ->SQLite3Connection))
+
+;; For testing!
+(defn- <? [p]
+  "Take a function producing a Promise, apply it with the given arguments and return an atom
+  containing the result on success.  Throw a JS error on failure."
+  (let [r (atom)]
+    (.then p
+           (fn [result] (reset! r result))
+           (fn [e] (throw (new js/Error e))))
+    r))
+
+(comment
+  (def db (<? (sqlite-connection "/Users/nalexander/test.db" :mode (bit-or 2 4))))
+  (def x (<? (s/each! @db "CREATE TABLE IF NOT EXISTS datoms (e BLOB, a BLOB, v BLOB, t BLOB)" nil nil)))
+  (def y (<? (s/each! @db "INSERT INTO datoms VALUES (?, ?, ?, ?)" nil :bindings [0, 1, 2, 8])))
+  (def z (<? (s/each! @db "SELECT * FROM datoms" (partial println "row"))))
+  (def w (<? (s/each! @db "DELETE FROM datoms" nil)))
+  )

--- a/src/datomish/sqlite.cljc
+++ b/src/datomish/sqlite.cljc
@@ -1,0 +1,26 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+(ns datomish.sqlite)
+
+(defprotocol ISQLiteConnection
+  (-each!
+    [db sql bindings row-cb]
+    "Execute the given SQL string with the specified bindings, invoking the given `row-cb` callback
+    function (if provided) with each returned row.  Each row will be presented to `row-cb` as a
+    map-like object, such that `(:column-name row)` succeeds.  Returns a Promise.")
+
+  (in-transaction!
+    [db f]
+    "Invoke `f` in a transaction.  Commit the transaction if and only if `f` resolves to a value;
+    otherwise, rollback the transaction.  Returns a Promise resolving to the value of `f` on
+    success.")
+
+  (close!
+    [db]
+    "Close this SQLite connection. Returns a Promise."))
+
+(defn each!
+  [db sql row-cb & {:keys [bindings]}]
+  (-each! db sql bindings row-cb))


### PR DESCRIPTION
@rnewman built on top of old, 'cuz lazy.

The idea here is to work out some minimal SQLite interface that can be provided by all of `sqlite3` (although I found `promise-sqlite` easier), `SQLite.jsm`, and `jdbc`.

I think it's possible to implement the protocol directly on the JS object, but I wasn't confident, and this is  pretty straightforward.