### PR TITLE
Support complex `or` expressions.

### DIFF
--- a/src/common/datomish/query.cljc
+++ b/src/common/datomish/query.cljc
@@ -63,13 +63,11 @@
   (let [inner-projection (projection/sql-projection-for-relation context)
         inner
         (merge
-          {:select inner-projection
-
-           ;; Always SELECT DISTINCT, because Datalog is set-based.
-           ;; TODO: determine from schema analysis whether we can avoid
-           ;; the need to do this.
-           :modifiers [:distinct]}
-          (clauses/cc->partial-subquery (:cc context)))
+          ;; Always SELECT DISTINCT, because Datalog is set-based.
+          ;; TODO: determine from schema analysis whether we can avoid
+          ;; the need to do this.
+          {:modifiers [:distinct]}
+          (clauses/cc->partial-subquery inner-projection (:cc context)))
 
         limit (:limit context)
         order-by (:order-by-vars context)]

--- a/src/common/datomish/query/clauses.cljc
+++ b/src/common/datomish/query/clauses.cljc
@@ -6,6 +6,7 @@
   (:require
    [datomish.query.cc :as cc]
    [datomish.query.functions :as functions]
+   [datomish.query.projection :refer [sql-projection-for-simple-variable-list]]
    [datomish.query.source
     :refer [pattern->schema-value-type
             attribute-in-source
@@ -18,6 +19,7 @@
     #?@(:cljs
         [:refer
          [
+          And
           Constant
           DefaultSrc
           Function
@@ -35,6 +37,7 @@
   #?(:clj
      (:import
       [datascript.parser
+       And
        Constant
        DefaultSrc
        Function
@@ -50,6 +53,8 @@
 ;; Pattern building is recursive, so we need forward declarations.
 (declare
   Not->NotJoinClause not-join->where-fragment
+  expand-pattern-clauses
+  complex-or->cc
   simple-or? simple-or->cc)
 
 (defn- check-or-apply-value-type [cc value-type pattern-part]
@@ -204,17 +209,16 @@
   ;; Otherwise -- perhaps each leg of the `or` binds different variables, which
   ;; is acceptable for an `or-join` form -- we need to turn this into a joined
   ;; subquery.
+  (let [f (if (simple-or? orc) simple-or->cc complex-or->cc)]
+    (cc/merge-ccs
+      cc
+      (f (:source cc)
+         (:known-types cc)
+         (merge-with concat
+                     (:external-bindings cc)
+                     (:bindings cc))
+         orc))))
 
-  (if (simple-or? orc)
-    (cc/merge-ccs cc (simple-or->cc (:source cc)
-                                    (:known-types cc)
-                                    (merge-with concat
-                                                (:external-bindings cc)
-                                                (:bindings cc))
-                                    orc))
-
-    ;; TODO: handle And within the Or patterns.
-    (raise "Non-simple `or` clauses not yet supported." {:clause orc})))
 
 (defn apply-function-clause [cc function]
   (or (functions/apply-sql-function cc function)
@@ -225,6 +229,9 @@
   (condp instance? it
     Or
     (apply-or-clause cc it)
+
+    And
+    (expand-pattern-clauses cc (:clauses it))
 
     Not
     (apply-not-clause cc it)
@@ -391,3 +398,90 @@
                                        (conj acc (cons :and w)))))
                              []
                              (cons primary ccs)))])))))
+
+(defn complex-or->cc
+  [source known-types external-bindings orc]
+  (validate-or-clause orc)
+
+  ;; Step one: any clauses that are standalone patterns might differ only in
+  ;; attribute. In that case, we can treat them as a 'simple or' -- a single
+  ;; pattern with a WHERE clause that alternates on the attribute.
+  ;; Pull those out first.
+  ;;
+  ;; Step two: for each cluster of patterns, and for each `and`, recursively
+  ;; build a CC and simple projection. The projection must be the same for each
+  ;; CC, because we will concatenate these with a `UNION`.
+  ;;
+  ;; Finally, we alias this entire UNION block as a FROM; it can be stitched into
+  ;; the outer query by looking at the projection.
+  ;;
+  ;; For example,
+  ;;
+  ;;   [:find ?page :in $ ?string :where
+  ;;    (or [?page :page/title ?string]
+  ;;        [?page :page/excerpt ?string]
+  ;;        (and [?save :save/string ?string]
+  ;;             [?page :page/save ?save]))]
+  ;;
+  ;; would expand to
+  ;;
+  ;; SELECT or123.page AS page FROM
+  ;;  (SELECT datoms124.e AS page FROM datoms AS datoms124
+  ;;   WHERE datoms124.v = ? AND
+  ;;         (datoms124.a = :page/title OR
+  ;;          datoms124.a = :page/excerpt)
+  ;;   UNION
+  ;;   SELECT datoms126.e AS page FROM datoms AS datoms125, datoms AS datoms126
+  ;;   WHERE datoms125.a = :save/string AND
+  ;;         datoms125.v = ? AND
+  ;;         datoms126.v = datoms125.e AND
+  ;;         datoms126.a = :page/save)
+  ;;  AS or123
+  ;;
+  ;; Note that a top-level standalone `or` doesn't really need to be aliased, but
+  ;; it shouldn't do any harm.
+
+  (if (= 1 (count (:clauses orc)))
+    ;; Well, this is silly.
+    (pattern->cc source (first (:clauses orc)) known-types external-bindings)
+
+    ;; TODO: pull out simple patterns.
+    (let [
+          ;; First: turn each arm of the `or` into a CC. We can easily turn this
+          ;; into SQL.
+          ccs (map (fn [p] (pattern->cc source p known-types external-bindings))
+                   (:clauses orc))
+
+          free-vars (:free (:rule-vars orc))
+
+          ;; Second: wrap an equivalent projection around each. The Or knows which
+          ;; variables to use.
+          projection-list-fn
+          (partial sql-projection-for-simple-variable-list
+                   free-vars)
+
+          ;; Third: turn each CC and projection into an arm of a UNION.
+          subqueries {:union (map (fn [cc]
+                                    (cc->partial-subquery (projection-list-fn cc)
+                                                          cc))
+                                  ccs)}
+
+
+          ;; Fourth: map this query to an alias in `:from`, and establish bindings
+          ;; so that the enclosing query and projection know which names to use.
+          ;; Finally, return a CC that can be merged.
+          alias ((:table-alias source) :orjoin)
+          bindings (into {} (map (fn [var]
+                                   (let [sym (:symbol var)]
+                                     [sym [(sql/qualify alias (util/var->sql-var sym))]]))
+                                 free-vars))]
+
+      (cc/map->ConjoiningClauses
+        {:source source
+         :from [[subqueries alias]]
+         :known-types (apply merge (map :known-types ccs))
+         :extracted-types (apply merge (map :extracted-types ccs))
+         :external-bindings {}       ; No need: caller will merge.
+         :bindings bindings
+         :ctes {}
+         :wheres []}))))

--- a/src/common/datomish/query/clauses.cljc
+++ b/src/common/datomish/query/clauses.cljc
@@ -245,27 +245,37 @@
   [cc patterns]
   (reduce apply-clause cc patterns))
 
+(defn- make-cc [source known-types external-bindings]
+  (cc/map->ConjoiningClauses
+    {:source source
+     :from []
+     :known-types (or known-types {})
+     :extracted-types {}
+     :external-bindings (or external-bindings {})
+     :bindings {}
+     :ctes {}
+     :wheres []}))
+
+(defn pattern->cc [source pattern known-types external-bindings]
+  (cc/expand-where-from-bindings
+    (apply-clause
+      (make-cc source known-types external-bindings)
+      pattern)))
+
 (defn patterns->cc [source patterns known-types external-bindings]
   (cc/expand-where-from-bindings
     (expand-pattern-clauses
-      (cc/map->ConjoiningClauses
-        {:source source
-         :from []
-         :known-types (or known-types {})
-         :extracted-types {}
-         :external-bindings (or external-bindings {})
-         :bindings {}
-         :ctes {}
-         :wheres []})
+      (make-cc source known-types external-bindings)
       patterns)))
 
 (defn cc->partial-subquery
   "Build part of a honeysql query map from a CC: the `:from` and `:where` parts.
   This allows for reuse both in top-level query generation and also for
   subqueries and NOT EXISTS clauses."
-  [cc]
+  [select cc]
   (merge
-    {:from (:from cc)}
+    {:select select
+     :from (:from cc)}
     (when-not (empty? (:ctes cc))
       {:with (:ctes cc)})
     (when-not (empty? (:wheres cc))
@@ -296,7 +306,7 @@
      (cons :and (:wheres (:cc not-join)))
 
      ;; If it does establish bindings, then it has to be a subquery.
-     [:exists (merge {:select [1]} (cc->partial-subquery (:cc not-join)))])])
+     [:exists (cc->partial-subquery [1] (:cc not-join))])])
 
 
 ;; A simple Or clause is one in which each branch can be evaluated against

--- a/src/common/datomish/query/projection.cljc
+++ b/src/common/datomish/query/projection.cljc
@@ -170,6 +170,25 @@
                 (symbol->projection var lookup-fn known-types type-proj-fn))
               full-var-list))))
 
+;; Like sql-projection-for-relation, but exposed for simpler
+;; use (e.g., in handling complex `or` patterns).
+(defn sql-projection-for-simple-variable-list [elements cc]
+  {:pre [(every? (partial instance? Variable) elements)]}
+  (let [{:keys [known-types extracted-types]} cc
+
+        projected-vars
+        (map variable->var elements)
+
+        type-proj-fn
+        (partial type-projection extracted-types)
+
+        lookup-fn
+        (partial lookup-variable cc)]
+
+    (mapcat (fn [var]
+              (symbol->projection var lookup-fn known-types type-proj-fn))
+            projected-vars)))
+
 (defn sql-projection-for-aggregation
   "Project an element list that contains aggregates. This expects a subquery
    aliased to `inner-table` which itself will project each var with the


### PR DESCRIPTION
Fixes #57.

This is _almost_ done — it passes a test, but that test has the `or` at the top level, and thus doesn't exercise one spot in which I left a `TODO`. More tomorrow, but feel free to skim already, @ncalexan.