### PR TITLE
Critical sections and listeners, updated

### DIFF
--- a/src/common/datomish/api.cljc
+++ b/src/common/datomish/api.cljc
@@ -26,6 +26,10 @@
 
 (def <transact! transact/<transact!)
 
+(def listen! transact/listen!)
+(def listen-chan! transact/listen-chan!)
+(def unlisten-chan! transact/unlisten-chan!)
+
 ;; TODO: use Potemkin, or a subset of Potemkin that is CLJS friendly (like
 ;; https://github.com/ztellman/potemkin/issues/31) to improve this re-exporting process.
 (def <close transact/close)

--- a/src/common/datomish/db.cljc
+++ b/src/common/datomish/db.cljc
@@ -111,9 +111,12 @@
 
   (in-transaction!
     [db chan-fn]
-    "Evaluate the given pair-chan `chan-fn` in an exclusive transaction. If it returns non-nil,
-    commit the transaction; otherwise, rollback the transaction.  Returns a pair-chan resolving to
-    the pair-chan returned by `chan-fn`.")
+    "Evaluate the given `chan-fn` in an exclusive transaction. If it returns non-nil,
+    commit the transaction; otherwise, rollback the transaction.
+
+    `chan-fn` should be a function of no arguments returning a pair-chan.
+
+    Returns a pair-chan resolving to the same pair as the pair-chan returned by `chan-fn`.")
 
   (<bootstrapped? [db]
     "Return true if this database has no transactions yet committed.")
@@ -818,14 +821,14 @@
    (<?q db find {}))
   ([db find options]
    (let [unexpected (seq (clojure.set/difference (set (keys options)) #{:limit :order-by :inputs}))]
-    (when unexpected
-      (raise "Unexpected options: " unexpected {:bad-options unexpected})))
+     (when unexpected
+       (raise "Unexpected options: " unexpected {:bad-options unexpected})))
    (let [{:keys [limit order-by inputs]} options
          parsed (query/parse find)
          context (-> db
-                   query-context
-                   (query/options-into-context limit order-by)
-                   (query/find-into-context parsed))
+                     query-context
+                     (query/options-into-context limit order-by)
+                     (query/find-into-context parsed))
 
          ;; We turn each row into either an array of values or an unadorned
          ;; value. The row-pair-transducer does this work.

--- a/src/common/datomish/transact.cljc
+++ b/src/common/datomish/transact.cljc
@@ -50,12 +50,18 @@
 (defrecord Connection [closed? current-db transact-chan]
   IConnection
   (close [conn]
-    (if (compare-and-set! (:closed? conn) false true)
-      (do
-        ;; This immediately stops <transact! enqueueing new work.
-        (a/close! (:transact-chan conn))
-        (db/close-db @(:current-db conn)))
-      (go [nil nil])))
+    (go-pair ;; Always want to return a pair-chan.
+      (when (compare-and-set! (:closed? conn) false true)
+        (let [result (a/chan 1)]
+          ;; Ask for the underlying database to be closed while draining the queue.  Invariant: we
+          ;; only ever see :sentinel-close in the transactor once.
+          (a/put! (:transact-chan conn) [:sentinel-close nil result true])
+          ;; This immediately stops <transact! enqueueing new transactions.
+          (a/close! (:transact-chan conn))
+          ;; The transactor will close the underlying DB after draining the queue; by waiting for
+          ;; result, we can raise any error from closing the DB and ensure that the DB is really
+          ;; closed after waiting for the connection to close.
+          (<? result)))))
 
   (db [conn] @(:current-db conn))
 
@@ -583,7 +589,7 @@
    {:pre [(conn? conn)]}
    ;; Any race to put! is a real race between callers of <transact!.  We can't just park on put!,
    ;; because the parked putter that is woken is non-deterministic.
-   (let [closed? (not (a/put! (:transact-chan conn) [tx-data result close?]))]
+   (let [closed? (not (a/put! (:transact-chan conn) [:sentinel-transact tx-data result close?]))]
      (go-pair
        ;; We want to return a pair-chan, no matter what kind of channel result is.
        (if closed?
@@ -596,20 +602,30 @@
       (>! token-chan (gensym "transactor-token"))
       (loop []
         (when-let [token (<! token-chan)]
-          (when-let [[tx-data result close?] (<! (:transact-chan conn))]
+          (when-let [[sentinel tx-data result close?] (<! (:transact-chan conn))]
             (let [pair
                   (<! (go-pair ;; Catch exceptions, return the pair.
-                        (let [db (db conn)
-                              report (<? (db/in-transaction!
-                                           db
-                                           #(-> (<with db tx-data))))]
-                          (when report
-                            ;; <with returns non-nil or throws, but we still check report just in
-                            ;; case.  Here, in-transaction! function completed and returned non-nil,
-                            ;; so the transaction has committed.
-                            (reset! (:current-db conn) (:db-after report))
-                            (>! (:listener-source conn) report))
-                          report)))]
+                        (case sentinel
+                          :sentinel-close
+                          ;; Time to close the underlying DB.
+                          (<? (db/close-db @(:current-db conn)))
+
+                          ;; Default: process the transaction.
+                          (do
+                            (when @(:closed? conn)
+                              ;; Drain enqueued transactions.
+                              (raise "Connection is closed" {:error :transact/connection-closed}))
+                            (let [db (db conn)
+                                  report (<? (db/in-transaction!
+                                               db
+                                               #(-> (<with db tx-data))))]
+                              (when report
+                                ;; <with returns non-nil or throws, but we still check report just in
+                                ;; case.  Here, in-transaction! function completed and returned non-nil,
+                                ;; so the transaction has committed.
+                                (reset! (:current-db conn) (:db-after report))
+                                (>! (:listener-source conn) report))
+                              report)))))]
               ;; Even when report is nil (transaction not committed), pair is non-nil.
               (>! result pair))
             (>! token-chan token)

--- a/test/datomish/test.cljs
+++ b/test/datomish/test.cljs
@@ -9,6 +9,7 @@
    datomish.schema-test
    datomish.sqlite-user-version-test
    datomish.tofinoish-test
+   datomish.transact-test
    datomish.util-test
    datomish.test.transforms
    datomish.test.query
@@ -23,6 +24,7 @@
   'datomish.schema-test
   'datomish.sqlite-user-version-test
   'datomish.tofinoish-test
+  'datomish.transact-test
   'datomish.util-test
   'datomish.test.transforms
   'datomish.test.query

--- a/test/datomish/test.cljs
+++ b/test/datomish/test.cljs
@@ -9,7 +9,7 @@
    datomish.schema-test
    datomish.sqlite-user-version-test
    datomish.tofinoish-test
-   datomish.test.util
+   datomish.util-test
    datomish.test.transforms
    datomish.test.query
    datomish.test-macros-test
@@ -23,7 +23,7 @@
   'datomish.schema-test
   'datomish.sqlite-user-version-test
   'datomish.tofinoish-test
-  'datomish.test.util
+  'datomish.util-test
   'datomish.test.transforms
   'datomish.test.query
   'datomish.test-macros-test)

--- a/test/datomish/transact_test.cljc
+++ b/test/datomish/transact_test.cljc
@@ -1,0 +1,116 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+(ns datomish.transact-test
+  #?(:cljs
+     (:require-macros
+      [datomish.pair-chan :refer [go-pair <?]]
+      [datomish.node-tempfile-macros :refer [with-tempfile]]
+      [cljs.core.async.macros :as a :refer [go go-loop]]))
+  (:require
+   [datomish.api :as d]
+   [datomish.db.debug :refer [<datoms-after <datoms>= <transactions-after <shallow-entity <fulltext-values]]
+   [datomish.util :as util #?(:cljs :refer-macros :clj :refer) [raise cond-let]]
+   [datomish.schema :as ds]
+   [datomish.simple-schema]
+   [datomish.sqlite :as s]
+   [datomish.sqlite-schema]
+   [datomish.datom]
+   #?@(:clj [[datomish.jdbc-sqlite]
+             [datomish.pair-chan :refer [go-pair <?]]
+             [tempfile.core :refer [tempfile with-tempfile]]
+             [datomish.test-macros :refer [deftest-async deftest-db]]
+             [clojure.test :as t :refer [is are deftest testing]]
+             [clojure.core.async :as a :refer [go go-loop <! >!]]])
+   #?@(:cljs [[datomish.js-sqlite]
+              [datomish.pair-chan]
+              [datomish.test-macros :refer-macros [deftest-async deftest-db]]
+              [datomish.node-tempfile :refer [tempfile]]
+              [cljs.test :as t :refer-macros [is are deftest testing async]]
+              [cljs.core.async :as a :refer [<! >!]]]))
+  #?(:clj
+     (:import [clojure.lang ExceptionInfo]))
+  #?(:clj
+     (:import [datascript.db DB])))
+
+#?(:cljs
+   (def Throwable js/Error))
+
+(defn- tempids [tx]
+  (into {} (map (juxt (comp :idx first) second) (:tempids tx))))
+
+(def test-schema
+  [{:db/id        (d/id-literal :db.part/user)
+    :db/ident     :x
+    :db/unique    :db.unique/identity
+    :db/valueType :db.type/long
+    :db.install/_attribute :db.part/db}
+   {:db/id        (d/id-literal :db.part/user)
+    :db/ident     :name
+    :db/unique    :db.unique/identity
+    :db/valueType :db.type/string
+    :db.install/_attribute :db.part/db}
+   {:db/id          (d/id-literal :db.part/user)
+    :db/ident       :y
+    :db/cardinality :db.cardinality/many
+    :db/valueType   :db.type/long
+    :db.install/_attribute :db.part/db}
+   {:db/id          (d/id-literal :db.part/user)
+    :db/ident       :aka
+    :db/cardinality :db.cardinality/many
+    :db/valueType   :db.type/string
+    :db.install/_attribute :db.part/db}
+   {:db/id        (d/id-literal :db.part/user)
+    :db/ident     :age
+    :db/valueType :db.type/long
+    :db.install/_attribute :db.part/db}
+   {:db/id        (d/id-literal :db.part/user)
+    :db/ident     :email
+    :db/unique    :db.unique/identity
+    :db/valueType :db.type/string
+    :db.install/_attribute :db.part/db}
+   {:db/id        (d/id-literal :db.part/user)
+    :db/ident     :spouse
+    :db/unique    :db.unique/value
+    :db/valueType :db.type/string
+    :db.install/_attribute :db.part/db}
+   {:db/id          (d/id-literal :db.part/user)
+    :db/ident       :friends
+    :db/cardinality :db.cardinality/many
+    :db/valueType   :db.type/ref
+    :db.install/_attribute :db.part/db}
+   ])
+
+(deftest-db test-overlapping-transacts conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))
+        report0   (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1)
+                                           :name  "Petr"}]))
+        id0       (get (tempids report0) -1)
+        n         5
+        make-t    (fn [i]
+                    ;; Be aware that a go block with a parking operation here
+                    ;; can change the order of transaction evaluation, since the
+                    ;; parking operation will be unparked non-deterministically.
+                    (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1)
+                                         :name  "Petr"
+                                         :email (str "@" i)}]))]
+
+    ;; Wait for all transactions to complete.
+    (<! (a/into []
+                (a/merge
+                  (map make-t (range n)))))
+
+    ;; Transactions should be processed in order.  This is an awkward way to
+    ;; express the expected data, but it's robust in the face of changing default
+    ;; identities, transaction numbers, and values of n.
+    (is (= (concat [[id0 :name "Petr" (+ 1 tx0) 1]
+                    [id0 :email "@0" (+ 2 tx0) 1]]
+                   (mapcat
+                     #(-> [[id0 :email (str "@" %) (+ 3 % tx0) 0]
+                           [id0 :email (str "@" (inc %)) (+ 3 % tx0) 1]])
+                     (range 0 (dec n))))
+
+           (filter #(not= :db/txInstant (second %)) (<? (<transactions-after (d/db conn) tx0)))))))
+
+#_ (time (t/run-tests))

--- a/test/datomish/transact_test.cljc
+++ b/test/datomish/transact_test.cljc
@@ -113,4 +113,100 @@
 
            (filter #(not= :db/txInstant (second %)) (<? (<transactions-after (d/db conn) tx0)))))))
 
+(deftest-db test-listeners conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))
+
+        c1  (a/chan (a/dropping-buffer 5))
+        c2  (a/chan (a/dropping-buffer 5))]
+
+    (testing "no listeners is okay"
+      ;; So that we can upsert to concrete entids.
+      (<? (d/<transact! conn [[:db/add 101 :name "Ivan"]
+                              [:db/add 102 :name "Petr"]])))
+
+    (testing "listeners are added, not accidentally notified of events before they were added"
+      (d/listen-chan! conn c1)
+      (d/listen-chan! conn c2)
+      ;; This is not authoritative, because in an error situation a report may
+      ;; be put! to a listener tap outside the expected flow.  We should witness
+      ;; such an occurrence later in the test.
+      (is (= nil (a/poll! c1)))
+      (is (= nil (a/poll! c2))))
+
+    (testing "unlistening to unrecognized key is ignored"
+      (d/unlisten-chan! conn (a/chan)))
+
+    (testing "listeners observe reports"
+      (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :name "Ivan"]]))
+      (is (= {-1 101}
+             (tempids (<! c1))))
+      (is (= {-1 101}
+             (tempids (<! c2))))
+      ;; Again, not authoritative.
+      (is (= nil (a/poll! c1)))
+      (is (= nil (a/poll! c2))))
+
+    (testing "unlisten removes correct listener"
+      (d/unlisten-chan! conn c1)
+
+      (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -2) :name "Petr"]]))
+      (is (= {-2 102}
+             (tempids (<! c2))))
+      ;; Again, not authoritative.
+      (is (= nil (a/poll! c1))))
+
+    (testing "returning to no listeners is okay"
+      (d/unlisten-chan! conn c2)
+
+      (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :name "Petr"]]))
+
+      ;; Again, not authoritative.
+      (is (= nil (a/poll! c1)))
+      (is (= nil (a/poll! c2)))
+
+      ;; This should be authoritative, however.  We should be able to put! due
+      ;; to the size of the buffer, and we should take! what we put!.
+      (>! c1 :token-1)
+      (is (= :token-1 (<! c1)))
+      (>! c2 :token-1)
+      (is (= :token-1 (<! c2))))
+
+    (testing "complains about blocking channels"
+      (is (thrown-with-msg?
+            ExceptionInfo #"unblocking buffers"
+            (d/listen-chan! conn (a/chan 1)))))
+    ))
+
+(deftest-db test-transact-in-listener conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))
+
+        ;; So that we can see all transactions.
+        lc  (a/chan (a/dropping-buffer 5))
+
+        ;; A oneshot listener, to prevent infinite recursion.
+        ofl (atom false)
+        ol  (fn [report]
+              (when (compare-and-set! ofl false true)
+                ;; Asynchronously throw another transaction at the wall.  This
+                ;; upserts to the earlier one.
+                (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :email "@1"}])))
+        ]
+
+    (testing "that we can invoke <transact! from within a listener"
+      (d/listen-chan! conn lc)
+      (d/listen! conn ol)
+
+      ;; Transact once to get started, and so that we can upsert against concrete ids.
+      (<? (d/<transact! conn [{:db/id 101 :name "Ivan"}]))
+      (is (= (+ 1 tx0) (:tx (<! lc))))
+
+      ;; The listener should have kicked off another transaction, but we can't
+      ;; wait for it explicitly.  However, we can wait for the report to hit the
+      ;; listening channel.
+      (let [r (<! lc)]
+        (is (= (+ 2 tx0) (:tx r)))
+        (is (= {-1 101}
+               (tempids r)))
+        (is (= nil (a/poll! lc)))))))
+
 #_ (time (t/run-tests))

--- a/test/datomish/transact_test.cljc
+++ b/test/datomish/transact_test.cljc
@@ -98,8 +98,8 @@
 
     ;; Wait for all transactions to complete.
     (<! (a/into []
-                (a/merge
-                  (map make-t (range n)))))
+                (a/merge ;; pair-chan's never stop providing values; use take to force close.
+                  (map #(a/take 1 (make-t %)) (range n)))))
 
     ;; Transactions should be processed in order.  This is an awkward way to
     ;; express the expected data, but it's robust in the face of changing default

--- a/test/datomish/util_test.cljc
+++ b/test/datomish/util_test.cljc
@@ -1,9 +1,9 @@
-(ns datomish.test.util
+(ns datomish.util-test
   (:require
-     [datomish.util :as util]
-     #?(:clj  [clojure.test :as t :refer [is are deftest testing]])
-     #?(:cljs [cljs.test :as t :refer-macros [is are deftest testing]])
-     ))
+   [datomish.util :as util]
+   #?(:clj  [clojure.test :as t :refer [is are deftest testing]])
+   #?(:cljs [cljs.test :as t :refer-macros [is are deftest testing]])
+   ))
 
 (deftest test-var-translation
   (is (= :x (util/var->sql-var '?x)))

--- a/test/datomish/util_test.cljc
+++ b/test/datomish/util_test.cljc
@@ -1,9 +1,14 @@
 (ns datomish.util-test
+  #?(:cljs
+     (:require-macros
+      [cljs.core.async.macros :as a :refer [go go-loop]]))
   (:require
    [datomish.util :as util]
-   #?(:clj  [clojure.test :as t :refer [is are deftest testing]])
-   #?(:cljs [cljs.test :as t :refer-macros [is are deftest testing]])
-   ))
+   #?@(:clj [[clojure.test :as t :refer [is are deftest testing]]
+             [clojure.core.async :as a :refer [go go-loop <! >!]]])
+
+   #?@(:cljs [[cljs.test :as t :refer-macros [is are deftest testing]]
+              [cljs.core.async :as a :refer [<! >!]]])))
 
 (deftest test-var-translation
   (is (= :x (util/var->sql-var '?x)))
@@ -35,3 +40,9 @@
              (catch :default e e))]
        (is (= "succeed" (aget caught "message")))
        (is (= {:foo 1} (aget caught "data"))))))
+
+(deftest test-unblocking-chan?
+  (is (util/unblocking-chan? (a/chan (a/dropping-buffer 10))))
+  (is (util/unblocking-chan? (a/chan (a/sliding-buffer 10))))
+  (is (util/unblocking-chan? (a/chan (util/unlimited-buffer))))
+  (is (not (util/unblocking-chan? (a/chan (a/buffer 10))))))


### PR DESCRIPTION
@rnewman -- this is an updated version of #80 and #61.  Listeners depends heavily on the exact form of transact, so here we are.

I ended up going with an unlimited buffer rather than a deque.  It's more likely we'll want an unlimited buffer in the future, tbh.  I removed the combinator (rather than fixing it) because we want a per-connection transaction critical section anyway, which was awkward to arrange; and so that we can explicitly close the transaction channel when we close the connection.  I also explicitly test the scenario where a listener calls `<transact!`, since that's so high value.  (Thinking aloud: it's so easy to make a mistake that we might want to try to catch recursive listeners.  Hmm...)

I simplified the listener interface, too, removing the explicit key and using the `mult`'s internal map instead.  Removes an atom and possible race conditions.

See what you think -- sorry it's a new PR.