### PR TITLE
Implement ident renaming and simple schema alteration. Fixes #103 and #78.

### DIFF
--- a/src/common/datomish/db_factory.cljc
+++ b/src/common/datomish/db_factory.cljc
@@ -87,11 +87,7 @@
           bootstrapped? (<? (db/<bootstrapped? db))]
       (when-not bootstrapped?
         ;; We need to bootstrap the DB.
-        (let [fail-alter-ident (fn [old new] (if-not (= old new)
-                                               (raise "Altering idents is not yet supported, got " new " altering existing ident " old
-                                                      {:error :schema/alter-idents :old old :new new})
-                                               new))
-              fail-alter-attr  (fn [old new] (if-not (= old new)
+        (let [fail-alter-attr  (fn [old new] (if-not (= old new)
                                                (raise "Altering schema attributes is not yet supported, got " new " altering existing schema attribute " old
                                                       {:error :schema/alter-schema :old old :new new})
                                                new))]
@@ -115,7 +111,7 @@
               ;; write to the database conveniently; without them, we'd have to manually write
               ;; datoms to the store.  It's feasible but awkward.)  After bootstrapping, we read
               ;; back the idents and schema, just like when we re-open.
-              (transact/<with-internal (bootstrap/tx-data) fail-alter-ident fail-alter-attr)
+              (transact/<with-internal (bootstrap/tx-data) fail-alter-attr)
               (<?))))
 
       ;; We just bootstrapped, or we are returning to an already bootstrapped DB.

--- a/src/common/datomish/schema.cljc
+++ b/src/common/datomish/schema.cljc
@@ -89,7 +89,7 @@
       (update-in acc [k] (fnil conj e) v))
     {} m))
 
-(defn- rschema [schema]
+(defn rschema [schema]
   (->>
     (for [[a kv] schema
           [k v]  kv

--- a/src/common/datomish/transact/bootstrap.cljc
+++ b/src/common/datomish/transact/bootstrap.cljc
@@ -36,6 +36,8 @@
                           :db/cardinality :db.cardinality/one}
    :db/noHistory         {:db/valueType   :db.type/boolean
                           :db/cardinality :db.cardinality/one}
+   :db.alter/attribute   {:db/valueType   :db.type/ref
+                          :db/cardinality :db.cardinality/many}
    })
 
 (def idents

--- a/src/common/datomish/util.cljc
+++ b/src/common/datomish/util.cljc
@@ -62,6 +62,12 @@
   [fn-kw x]
   (keyword (str "%" (name fn-kw) "." (name x))))
 
+(defn dissoc-from
+  "Given a map `m` and a key `k`, find the sub-map named by `k`
+   and remove all of its keys in `vs`."
+  [m k vs]
+  (assoc m k (apply dissoc (get m k) vs)))
+
 (defn concat-in
   {:static true}
   [m [k & ks] vs]

--- a/test/datomish/db_test.cljc
+++ b/test/datomish/db_test.cljc
@@ -306,29 +306,6 @@
         (is (= (tempids report)
                {-1 101}))))))
 
-(deftest-db test-add-ident conn
-  (is (= :test/ident (d/entid (d/db conn) :test/ident)))
-
-  (let [report   (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/db -1) :db/ident :test/ident]]))
-        eid      (get-in report [:tempids (d/id-literal :db.part/db -1)])]
-    (is (= eid (d/entid (d/db conn) :test/ident)))
-    (is (= :test/ident (d/ident (d/db conn) eid))))
-
-  ;; TODO: This should fail, but doesn't, due to stringification of :test/ident.
-  ;; (is (thrown-with-msg?
-  ;;       ExceptionInfo #"Retracting a :db/ident is not yet supported, got "
-  ;;       (<? (d/<transact! conn [[:db/retract 44 :db/ident :test/ident]]))))
-
-  ;; ;; Renaming looks like retraction and then assertion.
-  ;; (is (thrown-with-msg?
-  ;;       ExceptionInfo #"Retracting a :db/ident is not yet supported, got"
-  ;;       (<? (d/<transact! conn [[:db/add 44 :db/ident :other-name]]))))
-
-  ;; (is (thrown-with-msg?
-  ;;       ExceptionInfo #"Re-asserting a :db/ident is not yet supported, got"
-  ;;       (<? (d/<transact! conn [[:db/add 55 :db/ident :test/ident]]))))
-  )
-
 (deftest-db test-add-schema conn
   (let [es       [[:db/add :db.part/db :db.install/attribute (d/id-literal :db.part/db -1)]
                   {:db/id (d/id-literal :db.part/db -1)

--- a/test/datomish/schema_changes_test.cljc
+++ b/test/datomish/schema_changes_test.cljc
@@ -9,21 +9,22 @@
       [datomish.node-tempfile-macros :refer [with-tempfile]]
       [cljs.core.async.macros :as a :refer [go]]))
   (:require
-   [datomish.util :as util #?(:cljs :refer-macros :clj :refer) [raise cond-let]]
-   [datomish.sqlite :as s]
-
+   [datomish.api :as d]
    [datomish.datom :refer [datom]]
-
    [datomish.schema-changes :refer [datoms->schema-fragment]]
+   [datomish.sqlite :as s]
+   [datomish.util :as util #?(:cljs :refer-macros :clj :refer) [raise cond-let]]
 
    [datomish.db :as dm]
-   #?@(:clj [[datomish.pair-chan :refer [go-pair <?]]
+   #?@(:clj [[datomish.jdbc-sqlite]
+             [datomish.pair-chan :refer [go-pair <?]]
              [tempfile.core :refer [tempfile with-tempfile]]
-             [datomish.test-macros :refer [deftest-async]]
+             [datomish.test-macros :refer [deftest-async deftest-db]]
              [clojure.test :as t :refer [is are deftest testing]]
              [clojure.core.async :refer [go <! >!]]])
-   #?@(:cljs [[datomish.pair-chan]
-              [datomish.test-macros :refer-macros [deftest-async]]
+   #?@(:cljs [[datomish.js-sqlite]
+              [datomish.pair-chan]
+              [datomish.test-macros :refer-macros [deftest-async deftest-db]]
               [datomish.node-tempfile :refer [tempfile]]
               [cljs.test :as t :refer-macros [is are deftest testing async]]
               [cljs.core.async :as a :refer [<! >!]]]))
@@ -86,3 +87,71 @@
                [1 :db/valueType :db.value/string]]
               (map ->datom)
               (datoms->schema-fragment)))))))
+
+(deftest-db test-add-and-change-ident conn
+  ;; Passes through on failure.
+  (is (= :test/ident (d/entid (d/db conn) :test/ident)))
+
+  (let [report   (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/db -1) :db/ident :test/ident]]))
+        eid      (get-in report [:tempids (d/id-literal :db.part/db -1)])]
+    (is (= eid (d/entid (d/db conn) :test/ident)))
+    (is (= :test/ident (d/ident (d/db conn) eid)))
+
+    (testing "idents can be reasserted."
+      (<? (d/<transact! conn [[:db/add eid :db/ident :test/ident]])))
+
+    (testing "idents can't be reused while they're still active."
+      (is (thrown-with-msg?
+            ExceptionInfo #"Transaction violates unique constraint"
+            (<? (d/<transact! conn [[:db/add 5555 :db/ident :test/ident]])))))
+
+    (testing "idents can be changed."
+      ;; You can change an entity's ident.
+      (<? (d/<transact! conn [[:db/add eid :db/ident :test/anotherident]]))
+      (is (= eid (d/entid (d/db conn) :test/anotherident)))
+      (is (= :test/anotherident (d/ident (d/db conn) eid)))
+      (is (not (= eid (d/entid (d/db conn) :test/ident))))
+
+      ;; Passes through on failure.
+      (is (= :test/ident (d/entid (d/db conn) :test/ident))))
+
+    (testing "Once freed up, an ident can be reused."
+      (<? (d/<transact! conn [[:db/add 5555 :db/ident :test/ident]]))
+      (is (= 5555 (d/entid (d/db conn) :test/ident))))))
+
+(deftest-db test-change-schema-ident conn
+  ;; If an ident names an attribute, and is altered, then that attribute has
+  ;; changed in the schema.
+  (let [tempid (d/id-literal :db.part/db -1)
+        es [[:db/add :db.part/db :db.install/attribute tempid]
+            {:db/id tempid
+             :db/ident :test/someattr
+             :db/valueType :db.type/string
+             :db/cardinality :db.cardinality/one}]
+        report (<? (d/<transact! conn es))
+        db-after (:db-after report)
+        eid (get-in report [:tempids tempid])]
+
+    (testing "New ident is allocated"
+      (is (some? (d/entid db-after :test/someattr))))
+
+    (testing "Schema is modified"
+      (is (= (get-in db-after [:symbolic-schema :test/someattr])
+             {:db/valueType :db.type/string,
+              :db/cardinality :db.cardinality/one})))
+
+    (is (= eid (d/entid (d/db conn) :test/someattr)))
+
+    (testing "schema idents can be altered."
+      (let [report (<? (d/<transact! conn [{:db/id eid
+                                            :db/ident :test/otherattr}]))
+            db-after (:db-after report)]
+        (is (= eid (d/entid (d/db conn) :test/otherattr)))
+
+        ;; Passes through on failure.
+        (is (keyword? (d/entid (d/db conn) :test/someattr)))
+
+        (is (nil? (get-in db-after [:symbolic-schema :test/someattr])))
+        (is (= (get-in db-after [:symbolic-schema :test/otherattr])
+               {:db/valueType :db.type/string,
+                :db/cardinality :db.cardinality/one}))))))

--- a/test/datomish/test.cljs
+++ b/test/datomish/test.cljs
@@ -2,11 +2,11 @@
   (:require
    [doo.runner :refer-macros [doo-tests doo-all-tests]]
    [cljs.test :as t :refer-macros [is are deftest testing]]
+   datomish.schema-changes-test
    datomish.places.import-test
    datomish.promise-sqlite-test
    datomish.db-test
    datomish.query-test
-   datomish.schema-changes-test
    datomish.schema-test
    datomish.sqlite-user-version-test
    datomish.tofinoish-test
@@ -18,11 +18,11 @@
    ))
 
 (doo-tests
+  'datomish.schema-changes-test
   'datomish.places.import-test
   'datomish.promise-sqlite-test
   'datomish.db-test
   'datomish.query-test
-  'datomish.schema-changes-test
   'datomish.schema-test
   'datomish.sqlite-user-version-test
   'datomish.tofinoish-test

--- a/test/datomish/test.cljs
+++ b/test/datomish/test.cljs
@@ -6,6 +6,7 @@
    datomish.promise-sqlite-test
    datomish.db-test
    datomish.query-test
+   datomish.schema-changes-test
    datomish.schema-test
    datomish.sqlite-user-version-test
    datomish.tofinoish-test
@@ -21,6 +22,7 @@
   'datomish.promise-sqlite-test
   'datomish.db-test
   'datomish.query-test
+  'datomish.schema-changes-test
   'datomish.schema-test
   'datomish.sqlite-user-version-test
   'datomish.tofinoish-test


### PR DESCRIPTION
Done and working. You can now rename idents and attributes.