### PR TITLE
Stub out cli crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ Cargo.lock
 /classes/
 /node_modules/
 /out/
-/target/
+target/
 pom.xml
 pom.xml.asc
 /.cljs_node_repl/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: rust
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo build --verbose -p datomish-cli
+  - cargo test --verbose -p datomish-cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,11 @@ version = "0.4.0"
 authors = ["Richard Newman <rnewman@twinql.com>", "Nicholas Alexander <nalexander@mozilla.com>"]
 
 [dependencies]
+
+[dev-dependencies]
+[dev-dependencies.datomish-cli]
+  path = "cli"
+
+[[bin]]
+name = "datomish-cli"
+path = "cli/src/main.rs"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ To run tests use:
 cargo test
 ````
 
+To run the cli use:
+
+````
+cargo run
+````
+
 ## License
 
 Datomish is currently licensed under the Apache License v2.0. See the `LICENSE` file for details.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "datomish-cli"
+version = "0.0.1"
+
+[dependencies]
+[dependencies.datomish]
+  path = "../"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,8 +1,3 @@
 # datomish-cli
 
-Note: this isn't actually doing anything and is just a placeholder to get the project structure in place.  To run it locally, use:
-
-````
-cd cli
-cargo run
-````
+Note: this isn't actually doing anything and is just a placeholder to get the project structure in place.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,8 @@
+# datomish-cli
+
+Note: this isn't actually doing anything and is just a placeholder to get the project structure in place.  To run it locally, use:
+
+````
+cd cli
+cargo run
+````

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,21 +8,13 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+use std::env;
+extern crate datomish;
 
-pub fn get_name() -> String {
-  return String::from("datomish");
-}
+// This is just a placeholder to get the project structure in place.
+fn main() {
+    println!("Loaded {}", datomish::get_name());
 
-pub fn add_two(a: i32) -> i32 {
-    a + 2
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        assert_eq!(4, add_two(2));
-    }
+    let args: Vec<String> = env::args().collect();
+    println!("I got {:?} arguments: {:?}.", args.len() - 1, &args[1..]);
 }


### PR DESCRIPTION
This adds a cli/ subfolder that defines a crate that builds a binary that uses an exposed variable from datomish. It's just stubbed out and only is fetching a string from the core lib.

Then the main Cargo.toml references it as a dev-dependency so it can be run in ci.  The idea is that we would do the same thing for additional binaries (like a bulk importer).  This is building both and passing: https://travis-ci.org/mozilla/datomish/builds/184661695

