### PR TITLE
Take on rusqlite dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.4.0"
 authors = ["Richard Newman <rnewman@twinql.com>", "Nicholas Alexander <nalexander@mozilla.com>"]
 
 [dependencies]
+rusqlite = "0.8.0"
+
 [dependencies.datomish-query-parser]
   path = "query-parser"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 // specific language governing permissions and limitations under the License.
 
 extern crate datomish_query_parser;
+extern crate rusqlite;
+
+use rusqlite::Connection;
 
 pub fn get_name() -> String {
   return String::from("datomish");
@@ -19,18 +22,14 @@ pub fn get_parser_name() -> String {
   return datomish_query_parser::get_name();
 }
 
-pub fn add_two(a: i32) -> i32 {
-    a + 2
+// Will ultimately not return the sqlite connection directly
+pub fn get_connection() -> Connection {
+    return Connection::open_in_memory().unwrap();
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn it_works() {
-        assert_eq!(4, add_two(2));
-    }
 
     #[test]
     fn can_import_parser() {


### PR DESCRIPTION
Here's some more info about the various sqlite libraries: https://users.rust-lang.org/t/sqlite-libraries-potential-for-unification/8702.

They seem to take similar approaches, chose rusqlite based on activity and available docs to populate a simple test case.   Also, there's some discussion about unifying on it at https://github.com/dckc/rust-sqlite3/issues/46